### PR TITLE
Fix Python 3 compatibility on error

### DIFF
--- a/hererocks.py
+++ b/hererocks.py
@@ -93,7 +93,7 @@ def exec_command(capture, *args):
             return ""
 
         if not live_output:
-            sys.stdout.write(exception.output)
+            sys.stdout.write(exception.output.decode("UTF-8"))
 
         sys.exit("Error: got exitcode {} from command {}".format(
             exception.returncode, command))


### PR DESCRIPTION
This fixes a "TypeError: write() argument must eb str, not bytes" when
the compilation command fails.

(discovered this when trying to invoke hererocks on Windows which failed due to missing GCC)