### PR TITLE
Initial Windows port (mainly intended for easier Appveyor integration)

### DIFF
--- a/hererocks.py
+++ b/hererocks.py
@@ -76,17 +76,17 @@ def get_default_cache():
 def quote(command_arg):
     return "'" + command_arg.replace("'", "'\"'\"'") + "'"
 
-def exec_command(capture, *args):
-    command = " ".join(args)
+def exec_command(capture, *args, shell=True):
+    command = " ".join(args) if shell else args
 
     if opts.verbose:
-        print("Running " + command)
+        print("Running {}".format(command))
 
     live_output = opts.verbose and not capture
     runner = subprocess.check_call if live_output else subprocess.check_output
 
     try:
-        output = runner(command, stderr=subprocess.STDOUT, shell=True)
+        output = runner(command, stderr=subprocess.STDOUT, shell=shell)
     except subprocess.CalledProcessError as exception:
         if capture and not exception.output.strip():
             # Ignore errors if output is empty.
@@ -103,8 +103,8 @@ def exec_command(capture, *args):
 
     return capture and output.decode("UTF-8")
 
-def run_command(*args):
-    exec_command(False, *args)
+def run_command(*args, shell=True):
+    exec_command(False, *args, shell=True)
 
 def copy_dir(src, dst):
     shutil.copytree(src, dst, ignore=lambda _, __: {".git"})
@@ -844,16 +844,47 @@ class LuaRocks(Program):
 
         return False
 
+    def lua_version(self):
+        for lua in ("lua5.1", "lua", "luajit"):
+            lua_binary = os.path.join(opts.location, "bin", exe(lua))
+            if is_executable(lua_binary):
+                return exec_command(True, lua_binary, "-e",
+                        "print(_VERSION:sub(5))", shell=False).strip()
+        raise "Could not locate the LUA binary!"
+
+    def luarocks_help(self):
+        return exec_command(True, "install.bat", "/?").strip()
+
     def build(self):
         self.fetch()
-        print("Building LuaRocks" + self.version_suffix)
-        run_command("./configure", "--prefix=" + quote(opts.location),
-                    "--with-lua=" + quote(opts.location), "--force-config")
-        run_command("make" if self.is_luarocks_2_0() else "make build")
+        if self.win32_zip:
+            print("Building and installing LuaRocks" + self.version_suffix)
+            help_text = self.luarocks_help()
+            args = [
+                "install.bat",
+                "/P", os.path.join(opts.location, "LuaRocks"),
+                "/LUA", opts.location,
+                "/FORCECONFIG",
+            ]
+            if opts.target == "mingw":
+                args += ["/MW"]
+            # Since LuaRocks 2.0.13
+            if "/LV" in help_text:
+                args += ["/LV", self.lua_version()]
+            # Since LuaRocks 2.1.2
+            if "/NOREG" in help_text:
+                args += ["/NOREG", "/Q"]
+            run_command(*args, shell=False)
+        else:
+            print("Building LuaRocks" + self.version_suffix)
+            run_command("./configure", "--prefix=" + quote(opts.location),
+                        "--with-lua=" + quote(opts.location), "--force-config")
+            run_command("make" if self.is_luarocks_2_0() else "make build")
 
     def install(self):
-        print("Installing LuaRocks" + self.version_suffix)
-        run_command("make install")
+        if not self.win32_zip:
+            print("Installing LuaRocks" + self.version_suffix)
+            run_command("make install")
 
 def get_manifest_name():
     return os.path.join(opts.location, "hererocks.manifest")

--- a/hererocks.py
+++ b/hererocks.py
@@ -76,7 +76,8 @@ def get_default_cache():
 def quote(command_arg):
     return "'" + command_arg.replace("'", "'\"'\"'") + "'"
 
-def exec_command(capture, *args, shell=True):
+def exec_command(capture, *args, **kwargs):
+    shell = kwargs.get("shell", True)
     command = " ".join(args) if shell else args
 
     if opts.verbose:
@@ -103,8 +104,8 @@ def exec_command(capture, *args, shell=True):
 
     return capture and output.decode("UTF-8")
 
-def run_command(*args, shell=True):
-    exec_command(False, *args, shell=True)
+def run_command(*args, **kwargs):
+    exec_command(False, *args, **kwargs)
 
 def copy_dir(src, dst):
     shutil.copytree(src, dst, ignore=lambda _, __: {".git"})
@@ -849,7 +850,7 @@ class LuaRocks(Program):
             lua_binary = os.path.join(opts.location, "bin", exe(lua))
             if is_executable(lua_binary):
                 return exec_command(True, lua_binary, "-e",
-                        "print(_VERSION:sub(5))", shell=False).strip()
+                                    "print(_VERSION:sub(5))", shell=False).strip()
         raise "Could not locate the LUA binary!"
 
     def luarocks_help(self):


### PR DESCRIPTION
Addresses #8. A self-contained configuration example (with no external build scripts) can be found at https://github.com/Lekensteyn/luagcrypt/blob/767f9e8ce46c268df4d61c3e77b50f0f171d09e5/appveyor.yml.

Note that LuaRocks for Windows does not install to the same Lua directory because of limitations of their install.bat script. This is not a problem for Appveyor CI, but then either the README should be updated to reflect this difference, or the problem should be fixed (for example, by patching install.cmd).
___
Tested on Windows 7 x64 with MSVC12:

    "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat" x64
    hererocks.py C:\luatest -r^ --lua 5.3
    hererocks.py C:\luatest -r 2.2.2 --lua 5.2
    hererocks.py C:\luatest -r 2.0.10 --lua 5.1

Note:

 - LuaRocks <= 2.2.2 installs to $prefix\LuaRocks\2.2
 - LuaRocks >= 2.3 installs to $prefix\LuaRocks

TODO (for consistency with Linux): install to $prefix. Unfortunately
the Windows install.bat only offers the option to wipe $prefix before
installing, or aborting.